### PR TITLE
Pipeline fix for issue #10

### DIFF
--- a/src/simulator/cpu/pipeline-extended.cpu
+++ b/src/simulator/cpu/pipeline-extended.cpu
@@ -21,7 +21,8 @@
 		"ForkRs2":    {"type": "Fork", "x": 215, "y": 235, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRt3":    {"type": "Fork", "x": 220, "y": 255, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"NotStall":   {"type": "Not", "x": 175, "y": 2, "in": "In", "out": "Out"},
-		"ForkWrite":  {"type": "Fork", "x": 190, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
+		"OrWrite":    {"type": "Or", "x": 135, "y": 2, "in1": "In1", "in2": "In2", "out": "Out"},
+		"ForkWrite":  {"type": "Fork", "x": 150, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rs": 5, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
 
@@ -53,6 +54,7 @@
 		"ForkBr1":    {"type": "Fork", "x": 555, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr2":    {"type": "Fork", "x": 397, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr3":    {"type": "Fork", "x": 185, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
+		"ForkBr4":    {"type": "Fork", "x": 170, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"OrFlush":    {"type": "Or", "x": 375, "y": 70, "in1": "In1", "in2": "In2", "out": "Out"},
 
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
@@ -103,8 +105,9 @@
 		{"from": "ForkStall", "out": "Out1", "to": "OrFlush", "in": "In1", "points": [{"x": 382, "y": 5}], "end": {"x": 382, "y": 70}},
 		{"from": "OrFlush", "out": "Out", "to": "ID/EX", "in": "Flush", "start": {"x": 395, "y": 100}},
 		{"from": "ForkStall", "out": "Out2", "to": "NotStall", "in": "In", "end": {"x": 205, "y": 5}},
-		{"from": "NotStall", "out": "Out", "to": "ForkWrite", "in": "In", "start": {"x": 190, "y": 32}},
-		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write"},
+		{"from": "NotStall", "out": "Out", "to": "OrWrite", "in": "In1", "start": {"x": 175, "y": 12}, "end": {"x": 165, "y": 12}},
+		{"from": "OrWrite", "out": "Out", "to": "ForkWrite", "in": "In", "start": {"x": 150, "y": 32}},
+		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write", "points": [{"x": 190, "y": 50}]},
 		{"from": "ForkWrite", "out": "Out2", "to": "PC", "in": "Write", "points": [{"x": 55, "y": 50}]},
 
 		{"from": "ID/EX", "out": "ReadData1", "to": "MuxFwdA", "in": "0", "start": {"x": 405, "y": 248}, "end": {"x": 425, "y": 248}},
@@ -166,8 +169,10 @@
 		{"from": "ForkBr1", "out": "Out2", "to": "EX/MEM", "in": "Flush"},
 		{"from": "ForkBr2", "out": "Out1", "to": "ForkBr3", "in": "In"},
 		{"from": "ForkBr2", "out": "Out2", "to": "OrFlush", "in": "In2", "end": {"x": 397, "y": 70}},
-		{"from": "ForkBr3", "out": "Out1", "to": "MuxPC", "in": "PCSrc", "points": [{"x": 22, "y": 62}]},
+		{"from": "ForkBr3", "out": "Out1", "to": "ForkBr4", "in": "In"},
 		{"from": "ForkBr3", "out": "Out2", "to": "IF/ID", "in": "Flush"},
+		{"from": "ForkBr4", "out": "Out1", "to": "MuxPC", "in": "PCSrc", "points": [{"x": 22, "y": 62}]},
+		{"from": "ForkBr4", "out": "Out2", "to": "OrWrite", "in": "In2", "points": [{"x": 170, "y": 22}], "end": {"x": 165, "y": 22}},
 		{"from": "EX/MEM", "out": "MemRead", "to": "DataMem", "in": "MemRead", "start": {"x": 565, "y": 140}, "points": [{"x": 590, "y": 140}], "end": {"x": 590, "y": 242}},
 		{"from": "EX/MEM", "out": "MemWrite", "to": "DataMem", "in": "MemWrite", "start": {"x": 565, "y": 135}, "points": [{"x": 650, "y": 135}], "end": {"x": 650, "y": 242}},
 		{"from": "EX/MEM", "out": "MemToReg", "to": "MEM/WB", "in": "MemToReg", "start": {"x": 565, "y": 130}, "end": {"x": 680, "y": 130}},

--- a/src/simulator/cpu/pipeline-extended.cpu
+++ b/src/simulator/cpu/pipeline-extended.cpu
@@ -7,9 +7,9 @@
 		"ForkPCAdder":{"type": "Fork", "x": 155, "y": 175, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxPC":      {"type": "Multiplexer", "latency": 15, "x": 15, "y": 248, "size": 32, "sel": "PCSrc", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects PC+4 or the branch address as the new PC.", "pt": "Selecciona o PC+4 ou o endereço de branch como novo PC."}},
 		"InstMem":    {"type": "InstructionMemory", "latency": 300, "x": 90, "y": 215, "in": "Address", "out": "Instruction"},
-		
+
 		"IF/ID":      {"type": "PipelineRegister", "x": 180, "y": 110, "write": "Write", "flush": "Flush", "regs": {"NewPC": 32, "Instruction": 32}},
-		
+
 		"DistInst":   {"type": "Distributor", "x": 200, "y": 250, "in": {"id": "Instruction", "size": 32}, "out": [{"msb": 31, "lsb": 26}, {"msb": 25, "lsb": 21}, {"msb": 20, "lsb": 16},   {"msb": 15, "lsb": 11}, {"msb": 15, "lsb": 0}]},
 		"ForkRt":     {"type": "Fork", "x": 220, "y": 265, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"RegBank":    {"type": "RegBank", "latency": 100, "x": 260, "y": 215, "num_regs": 32, "read_reg1": "ReadReg1", "read_reg2": "ReadReg2", "read_data1": "ReadData1", "read_data2": "ReadData2", "write_reg": "WriteReg", "write_data": "WriteData", "reg_write": "RegWrite", "forwarding": true, "const_regs": [{"reg": 0, "val": 0}], "desc": {"default": "Holds all the MIPS registers and provides read/write to them.\nThe values of the ReadReg1 and ReadReg2 registers are read to the outputs.\nWriteData is written to the WriteReg register at the clock transition if RegWrite is enabled.\nWhen the same register is read from and written to in the same clock cycle, this register bank also forwards the written value to the output.", "pt": "Contém todos os registos do MIPS e fornece acesso de leitura/escrita aos mesmos.\nOs valores dos registos ReadReg1 e ReadReg2 são lidos para as saídas.\nWriteData é escrito para o registo WriteReg na transição do relógio se RegWrite estiver activo.\nQuando o mesmo registo é lido e escrito no mesmo ciclo de relógio, este banco de registos também encaminha o valor escrito para a saída."}},
@@ -22,9 +22,9 @@
 		"ForkRt3":    {"type": "Fork", "x": 220, "y": 255, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"NotStall":   {"type": "Not", "x": 175, "y": 2, "in": "In", "out": "Out"},
 		"ForkWrite":  {"type": "Fork", "x": 190, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
-		
+
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rs": 5, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
-		
+
 		"ForkReg":    {"type": "Fork", "x": 445, "y": 281, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxFwdA":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 230, "size": 32, "sel": "ForwardA", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 1st register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 1º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
 		"MuxFwdB":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 275, "size": 32, "sel": "ForwardB", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 2nd register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 2º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
@@ -40,9 +40,9 @@
 		"ForkImm":    {"type": "Fork", "x": 450, "y": 292, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRt2":    {"type": "Fork", "x": 408, "y": 381, "size": 5, "in": "In", "out": ["Out1", "Out2", "Out3"]},
 		"ForwardingUnit":   {"type": "ForwardingUnit", "latency": 50, "x": 470, "y": 410, "ex_mem_reg_write": "EX/MEM.RegWrite", "mem_wb_reg_write": "MEM/WB.RegWrite", "ex_mem_rd": "EX/MEM.Rd", "mem_wb_rd": "MEM/WB.Rd", "id_ex_rs": "ID/EX.Rs", "id_ex_rt": "ID/EX.Rt", "fwd_a": "ForwardA", "fwd_b": "ForwardB"},
-		
+
 		"EX/MEM":     {"type": "PipelineRegister", "x": 550, "y": 110, "regs": {"Result": 32, "ReadData2": 32, "Zero": 1, "RegBankDst": 5, "Target": 32, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
-		
+
 		"ForkMem":    {"type": "Fork", "x": 575, "y": 275, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkEXR1":   {"type": "Fork", "x": 575, "y": 360, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"DataMem":    {"type": "DataMemory", "latency": 400, "x": 580, "y": 242, "size": 100, "address": "Address", "write_data": "WriteData", "out": "ReadData", "mem_read": "MemRead", "mem_write": "MemWrite"},
@@ -54,9 +54,9 @@
 		"ForkBr2":    {"type": "Fork", "x": 397, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr3":    {"type": "Fork", "x": 185, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"OrFlush":    {"type": "Or", "x": 375, "y": 70, "in1": "In1", "in2": "In2", "out": "Out"},
-		
+
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"MuxMem":     {"type": "Multiplexer", "latency": 15, "x": 715, "y": 270, "size": 32, "sel": "MemToReg", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects the result of the ALU or the value read from memory to write to the destination register (WriteData).", "pt": "Selecciona o resultado da ALU ou o valor lido da memória para escrever no registo de destino (WriteData)."}},
 		"ForkRegWR2": {"type": "Fork", "x": 710, "y": 125, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkDst2":   {"type": "Fork", "x": 705, "y": 440, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
@@ -72,7 +72,7 @@
 		{"from": "MuxPC", "out": "Out", "to": "PC", "in": "NewPC"},
 		{"from": "ForkPCAdder", "out": "Out2", "to": "IF/ID", "in": "NewPC", "end": {"x": 180, "y": 175}},
 		{"from": "InstMem", "out": "Instruction", "to": "IF/ID", "in": "Instruction", "end": {"x": 180, "y": 265}},
-		
+
 		{"from": "IF/ID", "out": "NewPC", "to": "ID/EX", "in": "NewPC", "start": {"x": 195, "y": 175}, "end": {"x": 390, "y": 175}},
 		{"from": "IF/ID", "out": "Instruction", "to": "DistInst", "in": "Instruction", "start": {"x": 195, "y": 265}},
 		{"from": "DistInst", "out": "31-26", "to": "Control", "in": "Opcode", "start": {"x": 205, "y": 255}, "points": [{"x": 210, "y": 255}, {"x": 210, "y": 120}]},
@@ -106,7 +106,7 @@
 		{"from": "NotStall", "out": "Out", "to": "ForkWrite", "in": "In", "start": {"x": 190, "y": 32}},
 		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write"},
 		{"from": "ForkWrite", "out": "Out2", "to": "PC", "in": "Write", "points": [{"x": 55, "y": 50}]},
-		
+
 		{"from": "ID/EX", "out": "ReadData1", "to": "MuxFwdA", "in": "0", "start": {"x": 405, "y": 248}, "end": {"x": 425, "y": 248}},
 		{"from": "MuxFwdA", "out": "Out", "to": "ALU", "in": "In1", "start": {"x": 440, "y": 250}, "end": {"x": 480, "y": 250}},
 		{"from": "ID/EX", "out": "ReadData2", "to": "MuxFwdB", "in": "0", "start": {"x": 405, "y": 281}, "end": {"x": 425, "y": 281}},
@@ -146,7 +146,7 @@
 		{"from": "ID/EX", "out": "Rs", "to": "ForwardingUnit", "in": "ID/EX.Rs", "start": {"x": 405, "y": 372}, "points": [{"x": 413, "y": 372}, {"x": 413, "y": 426}]},
 		{"from": "ForwardingUnit", "out": "ForwardA", "to": "MuxFwdA", "in": "ForwardA", "points": [{"x": 493, "y": 400}, {"x": 441, "y": 400}, {"x": 441, "y": 270}, {"x": 432, "y": 270}], "end": {"x": 432, "y": 265}},
 		{"from": "ForwardingUnit", "out": "ForwardB", "to": "MuxFwdB", "in": "ForwardB", "points": [{"x": 516, "y": 405}, {"x": 432, "y": 405}], "end": {"x": 432, "y": 310}},
-		
+
 		{"from": "EX/MEM", "out": "RegBankDst", "to": "ForkDst1", "in": "In", "start": {"x": 565, "y": 387}},
 		{"from": "ForkDst1", "out": "Out1", "to": "MEM/WB", "in": "RegBankDst", "end": {"x": 680, "y": 387}},
 		{"from": "ForkDst1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.Rd", "points": [{"x": 570, "y": 420}]},
@@ -174,7 +174,7 @@
 		{"from": "EX/MEM", "out": "RegWrite", "to": "ForkRegWR1", "in": "In", "start": {"x": 565, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out1", "to": "MEM/WB", "in": "RegWrite", "end": {"x": 680, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.RegWrite", "points": [{"x": 670, "y": 430}]},
-		
+
 		{"from": "MEM/WB", "out": "ReadData", "to": "MuxMem", "in": "1", "start": {"x": 695, "y": 292}},
 		{"from": "MEM/WB", "out": "Result", "to": "MuxMem", "in": "0", "start": {"x": 695, "y": 360}, "points": [{"x": 702, "y": 360}, {"x": 702, "y": 281}]},
 		{"from": "MEM/WB", "out": "MemToReg", "to": "MuxMem", "in": "MemToReg", "start": {"x": 695, "y": 130}, "points": [{"x": 722, "y": 130}]},

--- a/src/simulator/cpu/pipeline-no-hazard-detection.cpu
+++ b/src/simulator/cpu/pipeline-no-hazard-detection.cpu
@@ -7,17 +7,17 @@
 		"ForkPCAdder":{"type": "Fork", "x": 155, "y": 175, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxPC":      {"type": "Multiplexer", "latency": 15, "x": 15, "y": 248, "size": 32, "sel": "PCSrc", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects PC+4 or the branch address as the new PC.", "pt": "Selecciona o PC+4 ou o endereço de branch como novo PC."}},
 		"InstMem":    {"type": "InstructionMemory", "latency": 300, "x": 90, "y": 215, "in": "Address", "out": "Instruction"},
-		
+
 		"IF/ID":      {"type": "PipelineRegister", "x": 180, "y": 110, "regs": {"NewPC": 32, "Instruction": 32}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"DistInst":   {"type": "Distributor", "x": 200, "y": 250, "in": {"id": "Instruction", "size": 32}, "out": [{"msb": 31, "lsb": 26}, {"msb": 25, "lsb": 21}, {"msb": 20, "lsb": 16},   {"msb": 15, "lsb": 11}, {"msb": 15, "lsb": 0}]},
 		"ForkRt":     {"type": "Fork", "x": 220, "y": 265, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"RegBank":    {"type": "RegBank", "latency": 100, "x": 260, "y": 215, "num_regs": 32, "read_reg1": "ReadReg1", "read_reg2": "ReadReg2", "read_data1": "ReadData1", "read_data2": "ReadData2", "write_reg": "WriteReg", "write_data": "WriteData", "reg_write": "RegWrite", "const_regs": [{"reg": 0, "val": 0}]},
 		"Control":    {"type": "ControlUnit", "latency": 50, "x": 230, "y": 70, "in": "Opcode"},
 		"ExtendImm":  {"type": "SignExtend", "x": 280, "y": 330, "in": {"id": "In", "size": 16}, "out": {"id": "Out", "size": 32}, "desc": {"default": "Extends the instruction's immediate value from 16 to 32 bits, in the case it is an I-type instruction.", "pt": "Estende o valor imediato da instrução de 16 para 32 bits, no caso de ser uma instrução do tipo I."}},
-		
+
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"ForkReg":    {"type": "Fork", "x": 410, "y": 281, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxReg":     {"type": "Multiplexer", "latency": 15, "x": 425, "y": 270, "size": 32, "sel": "ALUSrc", "out": "Out", "in": ["0", "1"], "desc": {"default": "Selects the value of the 2nd read register or the instruction's immediate value as the ALU's second operand.", "pt": "Selecciona o valor do 2º registo lido ou o valor imediato da instrução como segundo operando da ALU."}},
 		"DistImm":    {"type": "Distributor", "x": 413, "y": 330, "in": {"id": "In", "size": 32}, "out": [{"msb": 31, "lsb": 0}, {"msb": 5, "lsb": 0}]},
@@ -27,15 +27,15 @@
 		"ShiftImm":   {"type": "ShiftLeft", "x": 450, "y": 190, "in": {"id": "In", "size": 32}, "out": {"id": "Out", "size": 32}, "amount": 2, "desc": {"default": "The 2 less significant bits of the addresses of the instructions are always 00 (the addresses are multiples of 4). As such, these bits are not included in the instruction's immediate value (offset).\nThis component restores those bits by shifting the value 2 bits to the left (or multiplying by 4), in case it is a branch instruction.", "pt": "Os 2 bits menos significativos dos endereços das instruções são sempre 00 (os endereços são múltiplos de 4). Como tal, estes bits não são incluídos no valor imediato da instrução (offset).\nEste componente restaura esses bits deslocando o valor 2 bits para a esquerda (ou multiplicando por 4), no caso de ser uma instrução de branch."}},
 		"AddBranch":  {"type": "Add", "latency": 50, "x": 505, "y": 164, "in1": "In1", "in2": "In2", "out": "Out", "desc": {"default": "Adds the branch offset to the PC+4 to obtain the destination branch address, in case it is a branch instruction.", "pt": "Soma o offset do branch ao PC+4 para obter o endereço de destino do branch, no caso de ser uma instrução de branch."}},
 		"ForkImm":    {"type": "Fork", "x": 415, "y": 292, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
-		
+
 		"EX/MEM":     {"type": "PipelineRegister", "x": 550, "y": 110, "regs": {"Result": 32, "ReadData2": 32, "Zero": 1, "RegBankDst": 5, "Target": 32, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"ForkMem":    {"type": "Fork", "x": 572, "y": 275, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"DataMem":    {"type": "DataMemory", "latency": 400, "x": 580, "y": 242, "size": 100, "address": "Address", "write_data": "WriteData", "out": "ReadData", "mem_read": "MemRead", "mem_write": "MemWrite"},
 		"AndBranch":  {"type": "And", "x": 600, "y": 180, "in1": "Branch", "in2": "Zero", "out": "Branch", "desc": {"default": "Determines if a branch should occur.", "pt": "Determina se um branch será efectuado."}},
-		
+
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"MuxMem":     {"type": "Multiplexer", "latency": 15, "x": 710, "y": 270, "size": 32, "sel": "MemToReg", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects the result of the ALU or the value read from memory to write to the destination register (WriteData).", "pt": "Selecciona o resultado da ALU ou o valor lido da memória para escrever no registo de destino (WriteData)."}}
 	},
 	"wires": [
@@ -48,7 +48,7 @@
 		{"from": "MuxPC", "out": "Out", "to": "PC", "in": "NewPC"},
 		{"from": "ForkPCAdder", "out": "Out2", "to": "IF/ID", "in": "NewPC", "end": {"x": 180, "y": 175}},
 		{"from": "InstMem", "out": "Instruction", "to": "IF/ID", "in": "Instruction", "end": {"x": 180, "y": 265}},
-		
+
 		{"from": "IF/ID", "out": "NewPC", "to": "ID/EX", "in": "NewPC", "start": {"x": 195, "y": 175}, "end": {"x": 390, "y": 175}},
 		{"from": "IF/ID", "out": "Instruction", "to": "DistInst", "in": "Instruction", "start": {"x": 195, "y": 265}},
 		{"from": "DistInst", "out": "31-26", "to": "Control", "in": "Opcode", "start": {"x": 205, "y": 255}, "points": [{"x": 210, "y": 255}, {"x": 210, "y": 120}]},
@@ -69,7 +69,7 @@
 		{"from": "Control", "out": "MemWrite", "to": "ID/EX", "in": "MemWrite", "start": {"x": 290, "y": 135}, "end": {"x": 390, "y": 135}},
 		{"from": "Control", "out": "MemToReg", "to": "ID/EX", "in": "MemToReg", "start": {"x": 290, "y": 130}, "end": {"x": 390, "y": 130}},
 		{"from": "Control", "out": "RegWrite", "to": "ID/EX", "in": "RegWrite", "start": {"x": 290, "y": 125}, "end": {"x": 390, "y": 125}},
-		
+
 		{"from": "ID/EX", "out": "ReadData1", "to": "ALU", "in": "In1", "start": {"x": 405, "y": 248}, "end": {"x": 450, "y": 248}},
 		{"from": "ID/EX", "out": "ReadData2", "to": "ForkReg", "in": "In", "start": {"x": 405, "y": 281}},
 		{"from": "ForkReg", "out": "Out1", "to": "MuxReg", "in": "0"},
@@ -97,7 +97,7 @@
 		{"from": "ID/EX", "out": "MemWrite", "to": "EX/MEM", "in": "MemWrite", "start": {"x": 405, "y": 135}, "end": {"x": 550, "y": 135}},
 		{"from": "ID/EX", "out": "MemToReg", "to": "EX/MEM", "in": "MemToReg", "start": {"x": 405, "y": 130}, "end": {"x": 550, "y": 130}},
 		{"from": "ID/EX", "out": "RegWrite", "to": "EX/MEM", "in": "RegWrite", "start": {"x": 405, "y": 125}, "end": {"x": 550, "y": 125}},
-		
+
 		{"from": "EX/MEM", "out": "RegBankDst", "to": "MEM/WB", "in": "RegBankDst", "start": {"x": 565, "y": 387}, "end": {"x": 680, "y": 387}},
 		{"from": "EX/MEM", "out": "Result", "to": "ForkMem", "in": "In", "start": {"x": 565, "y": 275}},
 		{"from": "ForkMem", "out": "Out1", "to": "DataMem", "in": "Address"},
@@ -112,7 +112,7 @@
 		{"from": "EX/MEM", "out": "MemWrite", "to": "DataMem", "in": "MemWrite", "start": {"x": 565, "y": 135}, "points": [{"x": 650, "y": 135}], "end": {"x": 650, "y": 242}},
 		{"from": "EX/MEM", "out": "MemToReg", "to": "MEM/WB", "in": "MemToReg", "start": {"x": 565, "y": 130}, "end": {"x": 680, "y": 130}},
 		{"from": "EX/MEM", "out": "RegWrite", "to": "MEM/WB", "in": "RegWrite", "start": {"x": 565, "y": 125}, "end": {"x": 680, "y": 125}},
-		
+
 		{"from": "MEM/WB", "out": "ReadData", "to": "MuxMem", "in": "1", "start": {"x": 695, "y": 292}},
 		{"from": "MEM/WB", "out": "Result", "to": "MuxMem", "in": "0", "start": {"x": 695, "y": 360}, "points": [{"x": 702, "y": 360}, {"x": 702, "y": 281}]},
 		{"from": "MEM/WB", "out": "MemToReg", "to": "MuxMem", "in": "MemToReg", "start": {"x": 695, "y": 130}, "points": [{"x": 717, "y": 130}]},

--- a/src/simulator/cpu/pipeline-only-forwarding.cpu
+++ b/src/simulator/cpu/pipeline-only-forwarding.cpu
@@ -7,18 +7,18 @@
 		"ForkPCAdder":{"type": "Fork", "x": 155, "y": 175, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxPC":      {"type": "Multiplexer", "latency": 15, "x": 15, "y": 248, "size": 32, "sel": "PCSrc", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects PC+4 or the branch address as the new PC.", "pt": "Selecciona o PC+4 ou o endereço de branch como novo PC."}},
 		"InstMem":    {"type": "InstructionMemory", "latency": 300, "x": 90, "y": 215, "in": "Address", "out": "Instruction"},
-		
+
 		"IF/ID":      {"type": "PipelineRegister", "x": 180, "y": 110, "regs": {"NewPC": 32, "Instruction": 32}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"Distinst":   {"type": "Distributor", "x": 200, "y": 250, "in": {"id": "Instruction", "size": 32}, "out": [{"msb": 31, "lsb": 26}, {"msb": 25, "lsb": 21}, {"msb": 20, "lsb": 16},   {"msb": 15, "lsb": 11}, {"msb": 15, "lsb": 0}]},
 		"ForkRt":     {"type": "Fork", "x": 220, "y": 265, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"RegBank":    {"type": "RegBank", "latency": 100, "x": 260, "y": 215, "num_regs": 32, "read_reg1": "ReadReg1", "read_reg2": "ReadReg2", "read_data1": "ReadData1", "read_data2": "ReadData2", "write_reg": "WriteReg", "write_data": "WriteData", "reg_write": "RegWrite", "forwarding": true, "const_regs": [{"reg": 0, "val": 0}], "desc": {"default": "Holds all the MIPS registers and provides read/write to them.\nThe values of the ReadReg1 and ReadReg2 registers are read to the outputs.\nWriteData is written to the WriteReg register at the clock transition if RegWrite is enabled.\nWhen the same register is read from and written to in the same clock cycle, this register bank also forwards the written value to the output.", "pt": "Contém todos os registos do MIPS e fornece acesso de leitura/escrita aos mesmos.\nOs valores dos registos ReadReg1 e ReadReg2 são lidos para as saídas.\nWriteData é escrito para o registo WriteReg na transição do relógio se RegWrite estiver activo.\nQuando o mesmo registo é lido e escrito no mesmo ciclo de relógio, este banco de registos também encaminha o valor escrito para a saída."}},
 		"Control":    {"type": "ControlUnit", "latency": 50, "x": 230, "y": 70, "in": "Opcode"},
 		"ExtendImm":  {"type": "SignExtend", "x": 280, "y": 330, "in": {"id": "In", "size": 16}, "out": {"id": "Out", "size": 32}, "desc": {"default": "Extends the instruction's immediate value from 16 to 32 bits, in the case it is an I-type instruction.", "pt": "Estende o valor imediato da instrução de 16 para 32 bits, no caso de ser uma instrução do tipo I."}},
 		"ForkRs":     {"type": "Fork", "x": 230, "y": 235, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
-		
+
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rs": 5, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"ForkReg":    {"type": "Fork", "x": 445, "y": 281, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxFwdA":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 230, "size": 32, "sel": "ForwardA", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 1st register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 1º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
 		"MuxFwdB":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 275, "size": 32, "sel": "ForwardB", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 2nd register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 2º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
@@ -34,18 +34,18 @@
 		"ForkImm":    {"type": "Fork", "x": 450, "y": 292, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRt2":    {"type": "Fork", "x": 408, "y": 381, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"ForwardingUnit":{"type": "ForwardingUnit", "latency": 50, "x": 470, "y": 410, "ex_mem_reg_write": "EX/MEM.RegWrite", "mem_wb_reg_write": "MEM/WB.RegWrite", "ex_mem_rd": "EX/MEM.Rd", "mem_wb_rd": "MEM/WB.Rd", "id_ex_rs": "ID/EX.Rs", "id_ex_rt": "ID/EX.Rt", "fwd_a": "ForwardA", "fwd_b": "ForwardB"},
-		
+
 		"EX/MEM":     {"type": "PipelineRegister", "x": 550, "y": 110, "regs": {"Result": 32, "ReadData2": 32, "Zero": 1, "RegBankDst": 5, "Target": 32, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"ForkMem":    {"type": "Fork", "x": 575, "y": 275, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkEXR1":   {"type": "Fork", "x": 575, "y": 360, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"DataMem":    {"type": "DataMemory", "latency": 400, "x": 580, "y": 242, "size": 100, "address": "Address", "write_data": "WriteData", "out": "ReadData", "mem_read": "MemRead", "mem_write": "MemWrite"},
 		"AndBranch":  {"type": "And", "x": 600, "y": 180, "in1": "Branch", "in2": "Zero", "out": "Branch", "desc": {"default": "Determines if a branch should occur.", "pt": "Determina se um branch será efectuado."}},
 		"ForkDst1":   {"type": "Fork", "x": 570, "y": 387, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRegWR1": {"type": "Fork", "x": 670, "y": 125, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
-		
+
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"MuxMem":     {"type": "Multiplexer", "latency": 15, "x": 715, "y": 270, "size": 32, "sel": "MemToReg", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects the result of the ALU or the value read from memory to write to the destination register (WriteData).", "pt": "Selecciona o resultado da ALU ou o valor lido da memória para escrever no registo de destino (WriteData)."}},
 		"ForkRegWR2": {"type": "Fork", "x": 710, "y": 125, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkDst2":   {"type": "Fork", "x": 705, "y": 440, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
@@ -61,7 +61,7 @@
 		{"from": "MuxPC", "out": "Out", "to": "PC", "in": "NewPC"},
 		{"from": "ForkPCAdder", "out": "Out2", "to": "IF/ID", "in": "NewPC", "end": {"x": 180, "y": 175}},
 		{"from": "InstMem", "out": "Instruction", "to": "IF/ID", "in": "Instruction", "end": {"x": 180, "y": 265}},
-		
+
 		{"from": "IF/ID", "out": "NewPC", "to": "ID/EX", "in": "NewPC", "start": {"x": 195, "y": 175}, "end": {"x": 390, "y": 175}},
 		{"from": "IF/ID", "out": "Instruction", "to": "Distinst", "in": "Instruction", "start": {"x": 195, "y": 265}},
 		{"from": "Distinst", "out": "31-26", "to": "Control", "in": "Opcode", "start": {"x": 205, "y": 255}, "points": [{"x": 210, "y": 255}, {"x": 210, "y": 120}]},
@@ -84,7 +84,7 @@
 		{"from": "Control", "out": "MemWrite", "to": "ID/EX", "in": "MemWrite", "start": {"x": 290, "y": 135}, "end": {"x": 390, "y": 135}},
 		{"from": "Control", "out": "MemToReg", "to": "ID/EX", "in": "MemToReg", "start": {"x": 290, "y": 130}, "end": {"x": 390, "y": 130}},
 		{"from": "Control", "out": "RegWrite", "to": "ID/EX", "in": "RegWrite", "start": {"x": 290, "y": 125}, "end": {"x": 390, "y": 125}},
-		
+
 		{"from": "ID/EX", "out": "ReadData1", "to": "MuxFwdA", "in": "0", "start": {"x": 405, "y": 248}, "end": {"x": 425, "y": 248}},
 		{"from": "MuxFwdA", "out": "Out", "to": "ALU", "in": "In1", "start": {"x": 440, "y": 250}, "end": {"x": 480, "y": 250}},
 		{"from": "ID/EX", "out": "ReadData2", "to": "MuxFwdB", "in": "0", "start": {"x": 405, "y": 281}, "end": {"x": 425, "y": 281}},
@@ -121,7 +121,7 @@
 		{"from": "ID/EX", "out": "Rs", "to": "ForwardingUnit", "in": "ID/EX.Rs", "start": {"x": 405, "y": 372}, "points": [{"x": 413, "y": 372}, {"x": 413, "y": 426}]},
 		{"from": "ForwardingUnit", "out": "ForwardA", "to": "MuxFwdA", "in": "ForwardA", "points": [{"x": 493, "y": 400}, {"x": 441, "y": 400}, {"x": 441, "y": 270}, {"x": 432, "y": 270}], "end": {"x": 432, "y": 265}},
 		{"from": "ForwardingUnit", "out": "ForwardB", "to": "MuxFwdB", "in": "ForwardB", "points": [{"x": 516, "y": 405}, {"x": 432, "y": 405}], "end": {"x": 432, "y": 310}},
-		
+
 		{"from": "EX/MEM", "out": "RegBankDst", "to": "ForkDst1", "in": "In", "start": {"x": 565, "y": 387}},
 		{"from": "ForkDst1", "out": "Out1", "to": "MEM/WB", "in": "RegBankDst", "end": {"x": 680, "y": 387}},
 		{"from": "ForkDst1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.Rd", "points": [{"x": 570, "y": 420}]},
@@ -143,7 +143,7 @@
 		{"from": "EX/MEM", "out": "RegWrite", "to": "ForkRegWR1", "in": "In", "start": {"x": 565, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out1", "to": "MEM/WB", "in": "RegWrite", "end": {"x": 680, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.RegWrite", "points": [{"x": 670, "y": 430}]},
-		
+
 		{"from": "MEM/WB", "out": "ReadData", "to": "MuxMem", "in": "1", "start": {"x": 695, "y": 292}},
 		{"from": "MEM/WB", "out": "Result", "to": "MuxMem", "in": "0", "start": {"x": 695, "y": 360}, "points": [{"x": 702, "y": 360}, {"x": 702, "y": 281}]},
 		{"from": "MEM/WB", "out": "MemToReg", "to": "MuxMem", "in": "MemToReg", "start": {"x": 695, "y": 130}, "points": [{"x": 722, "y": 130}]},

--- a/src/simulator/cpu/pipeline.cpu
+++ b/src/simulator/cpu/pipeline.cpu
@@ -7,9 +7,9 @@
 		"ForkPCAdder":{"type": "Fork", "x": 155, "y": 175, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxPC":      {"type": "Multiplexer", "latency": 15, "x": 15, "y": 248, "size": 32, "sel": "PCSrc", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects PC+4 or the branch address as the new PC.", "pt": "Selecciona o PC+4 ou o endereço de branch como novo PC."}},
 		"InstMem":    {"type": "InstructionMemory", "latency": 300, "x": 90, "y": 215, "in": "Address", "out": "Instruction"},
-		
+
 		"IF/ID":      {"type": "PipelineRegister", "x": 180, "y": 110, "write": "Write", "flush": "Flush", "regs": {"NewPC": 32, "Instruction": 32}},
-		
+
 		"DistInst":   {"type": "Distributor", "x": 200, "y": 250, "in": {"id": "Instruction", "size": 32}, "out": [{"msb": 31, "lsb": 26}, {"msb": 25, "lsb": 21}, {"msb": 20, "lsb": 16},   {"msb": 15, "lsb": 11}, {"msb": 15, "lsb": 0}]},
 		"ForkRt":     {"type": "Fork", "x": 220, "y": 265, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"RegBank":    {"type": "RegBank", "latency": 100, "x": 260, "y": 215, "num_regs": 32, "read_reg1": "ReadReg1", "read_reg2": "ReadReg2", "read_data1": "ReadData1", "read_data2": "ReadData2", "write_reg": "WriteReg", "write_data": "WriteData", "reg_write": "RegWrite", "forwarding": true, "const_regs": [{"reg": 0, "val": 0}], "desc": {"default": "Holds all the MIPS registers and provides read/write to them.\nThe values of the ReadReg1 and ReadReg2 registers are read to the outputs.\nWriteData is written to the WriteReg register at the clock transition if RegWrite is enabled.\nWhen the same register is read from and written to in the same clock cycle, this register bank also forwards the written value to the output.", "pt": "Contém todos os registos do MIPS e fornece acesso de leitura/escrita aos mesmos.\nOs valores dos registos ReadReg1 e ReadReg2 são lidos para as saídas.\nWriteData é escrito para o registo WriteReg na transição do relógio se RegWrite estiver activo.\nQuando o mesmo registo é lido e escrito no mesmo ciclo de relógio, este banco de registos também encaminha o valor escrito para a saída."}},
@@ -22,9 +22,9 @@
 		"ForkRt3":    {"type": "Fork", "x": 220, "y": 255, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"NotStall":   {"type": "Not", "x": 175, "y": 2, "in": "Stall", "out": "Write"},
 		"ForkWrite":  {"type": "Fork", "x": 190, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
-		
+
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rs": 5, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
-		
+
 		"ForkReg":    {"type": "Fork", "x": 445, "y": 281, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"MuxFwdA":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 230, "size": 32, "sel": "ForwardA", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 1st register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 1º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
 		"MuxFwdB":    {"type": "Multiplexer", "latency": 15, "x": 425, "y": 275, "size": 32, "sel": "ForwardB", "out": "Out", "in": ["0", "1", "2"], "desc": {"default": "Selects, in conjunction with the forwarding unit, if the value of the 2nd register comes from the register bank or if it's forwarded from one of the next stages.", "pt": "Selecciona, em conjunto com a unidade de atalhos, se o valor do 2º registo vem do banco de registos ou se é encaminhado de uma das etapas seguintes."}},
@@ -40,9 +40,9 @@
 		"ForkImm":    {"type": "Fork", "x": 450, "y": 292, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRt2":    {"type": "Fork", "x": 408, "y": 381, "size": 5, "in": "In", "out": ["Out1", "Out2", "Out3"]},
 		"ForwardingUnit":{"type": "ForwardingUnit", "latency": 50, "x": 470, "y": 410, "ex_mem_reg_write": "EX/MEM.RegWrite", "mem_wb_reg_write": "MEM/WB.RegWrite", "ex_mem_rd": "EX/MEM.Rd", "mem_wb_rd": "MEM/WB.Rd", "id_ex_rs": "ID/EX.Rs", "id_ex_rt": "ID/EX.Rt", "fwd_a": "ForwardA", "fwd_b": "ForwardB"},
-		
+
 		"EX/MEM":     {"type": "PipelineRegister", "x": 550, "y": 110, "regs": {"Result": 32, "ReadData2": 32, "Zero": 1, "RegBankDst": 5, "Target": 32, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
-		
+
 		"ForkMem":    {"type": "Fork", "x": 575, "y": 275, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkEXR1":   {"type": "Fork", "x": 575, "y": 360, "size": 32, "in": "In", "out": ["Out1", "Out2"]},
 		"DataMem":    {"type": "DataMemory", "latency": 400, "x": 580, "y": 242, "size": 100, "address": "Address", "write_data": "WriteData", "out": "ReadData", "mem_read": "MemRead", "mem_write": "MemWrite"},
@@ -54,9 +54,9 @@
 		"ForkBr2":    {"type": "Fork", "x": 397, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr3":    {"type": "Fork", "x": 185, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"OrFlush":    {"type": "Or", "x": 375, "y": 70, "in1": "Stall", "in2": "Branch", "out": "Flush"},
-		
+
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
-		
+
 		"MuxMem":     {"type": "Multiplexer", "latency": 15, "x": 715, "y": 270, "size": 32, "sel": "MemToReg", "in": ["0", "1"], "out": "Out", "desc": {"default": "Selects the result of the ALU or the value read from memory to write to the destination register (WriteData).", "pt": "Selecciona o resultado da ALU ou o valor lido da memória para escrever no registo de destino (WriteData)."}},
 		"ForkRegWR2": {"type": "Fork", "x": 710, "y": 125, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkDst2":   {"type": "Fork", "x": 705, "y": 440, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
@@ -72,7 +72,7 @@
 		{"from": "MuxPC", "out": "Out", "to": "PC", "in": "NewPC"},
 		{"from": "ForkPCAdder", "out": "Out2", "to": "IF/ID", "in": "NewPC", "end": {"x": 180, "y": 175}},
 		{"from": "InstMem", "out": "Instruction", "to": "IF/ID", "in": "Instruction", "end": {"x": 180, "y": 265}},
-		
+
 		{"from": "IF/ID", "out": "NewPC", "to": "ID/EX", "in": "NewPC", "start": {"x": 195, "y": 175}, "end": {"x": 390, "y": 175}},
 		{"from": "IF/ID", "out": "Instruction", "to": "DistInst", "in": "Instruction", "start": {"x": 195, "y": 265}},
 		{"from": "DistInst", "out": "31-26", "to": "Control", "in": "Opcode", "start": {"x": 205, "y": 255}, "points": [{"x": 210, "y": 255}, {"x": 210, "y": 120}]},
@@ -106,7 +106,7 @@
 		{"from": "NotStall", "out": "Write", "to": "ForkWrite", "in": "In", "start": {"x": 190, "y": 32}},
 		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write"},
 		{"from": "ForkWrite", "out": "Out2", "to": "PC", "in": "Write", "points": [{"x": 55, "y": 50}]},
-		
+
 		{"from": "ID/EX", "out": "ReadData1", "to": "MuxFwdA", "in": "0", "start": {"x": 405, "y": 248}, "end": {"x": 425, "y": 248}},
 		{"from": "MuxFwdA", "out": "Out", "to": "ALU", "in": "In1", "start": {"x": 440, "y": 250}, "end": {"x": 480, "y": 250}},
 		{"from": "ID/EX", "out": "ReadData2", "to": "MuxFwdB", "in": "0", "start": {"x": 405, "y": 281}, "end": {"x": 425, "y": 281}},
@@ -146,7 +146,7 @@
 		{"from": "ID/EX", "out": "Rs", "to": "ForwardingUnit", "in": "ID/EX.Rs", "start": {"x": 405, "y": 372}, "points": [{"x": 413, "y": 372}, {"x": 413, "y": 426}]},
 		{"from": "ForwardingUnit", "out": "ForwardA", "to": "MuxFwdA", "in": "ForwardA", "points": [{"x": 493, "y": 400}, {"x": 441, "y": 400}, {"x": 441, "y": 270}, {"x": 432, "y": 270}], "end": {"x": 432, "y": 265}},
 		{"from": "ForwardingUnit", "out": "ForwardB", "to": "MuxFwdB", "in": "ForwardB", "points": [{"x": 516, "y": 405}, {"x": 432, "y": 405}], "end": {"x": 432, "y": 310}},
-		
+
 		{"from": "EX/MEM", "out": "RegBankDst", "to": "ForkDst1", "in": "In", "start": {"x": 565, "y": 387}},
 		{"from": "ForkDst1", "out": "Out1", "to": "MEM/WB", "in": "RegBankDst", "end": {"x": 680, "y": 387}},
 		{"from": "ForkDst1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.Rd", "points": [{"x": 570, "y": 420}]},
@@ -174,7 +174,7 @@
 		{"from": "EX/MEM", "out": "RegWrite", "to": "ForkRegWR1", "in": "In", "start": {"x": 565, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out1", "to": "MEM/WB", "in": "RegWrite", "end": {"x": 680, "y": 125}},
 		{"from": "ForkRegWR1", "out": "Out2", "to": "ForwardingUnit", "in": "EX/MEM.RegWrite", "points": [{"x": 670, "y": 430}]},
-		
+
 		{"from": "MEM/WB", "out": "ReadData", "to": "MuxMem", "in": "1", "start": {"x": 695, "y": 292}},
 		{"from": "MEM/WB", "out": "Result", "to": "MuxMem", "in": "0", "start": {"x": 695, "y": 360}, "points": [{"x": 702, "y": 360}, {"x": 702, "y": 281}]},
 		{"from": "MEM/WB", "out": "MemToReg", "to": "MuxMem", "in": "MemToReg", "start": {"x": 695, "y": 130}, "points": [{"x": 722, "y": 130}]},

--- a/src/simulator/cpu/pipeline.cpu
+++ b/src/simulator/cpu/pipeline.cpu
@@ -21,7 +21,8 @@
 		"ForkRs2":    {"type": "Fork", "x": 215, "y": 235, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkRt3":    {"type": "Fork", "x": 220, "y": 255, "size": 5, "in": "In", "out": ["Out1", "Out2"]},
 		"NotStall":   {"type": "Not", "x": 175, "y": 2, "in": "Stall", "out": "Write"},
-		"ForkWrite":  {"type": "Fork", "x": 190, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
+		"OrWrite":    {"type": "Or", "x": 135, "y": 2, "in1": "In1", "in2": "In2", "out": "Out"},
+		"ForkWrite":  {"type": "Fork", "x": 150, "y": 50, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 
 		"ID/EX":      {"type": "PipelineRegister", "x": 390, "y": 110, "regs": {"ReadData1": 32, "ReadData2": 32, "NewPC": 32, "Imm": 32, "Rs": 5, "Rt": 5, "Rd": 5, "RegDst": 1, "ALUOp": 2, "ALUSrc": 1, "Branch": 1, "MemRead": 1, "MemWrite": 1, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.\nIf Flush is active, all values are set to zero, inserting a NOP instruction.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente.\nSe Flush estiver activo, todos os valores são colocados a zero, inserindo uma instrução NOP."}},
 
@@ -53,6 +54,7 @@
 		"ForkBr1":    {"type": "Fork", "x": 555, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr2":    {"type": "Fork", "x": 397, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"ForkBr3":    {"type": "Fork", "x": 185, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
+		"ForkBr4":    {"type": "Fork", "x": 170, "y": 62, "size": 1, "in": "In", "out": ["Out1", "Out2"]},
 		"OrFlush":    {"type": "Or", "x": 375, "y": 70, "in1": "Stall", "in2": "Branch", "out": "Flush"},
 
 		"MEM/WB":     {"type": "PipelineRegister", "x": 680, "y": 110, "regs": {"Result": 32, "ReadData": 32, "RegBankDst": 5, "MemToReg": 1, "RegWrite": 1}, "desc": {"default": "Register that separates two pipeline stages.\nThe values that transition to the next stage are stored here temporarily.", "pt": "Registo que separa duas etapas do pipeline.\nOs valores que transitam para a próxima etapa são armazenados aqui temporariamente."}},
@@ -103,9 +105,9 @@
 		{"from": "ForkStall", "out": "Out1", "to": "OrFlush", "in": "Stall", "points": [{"x": 382, "y": 5}], "end": {"x": 382, "y": 70}},
 		{"from": "OrFlush", "out": "Flush", "to": "ID/EX", "in": "Flush", "start": {"x": 395, "y": 100}},
 		{"from": "ForkStall", "out": "Out2", "to": "NotStall", "in": "Stall", "end": {"x": 205, "y": 5}},
-		{"from": "NotStall", "out": "Write", "to": "ForkWrite", "in": "In", "start": {"x": 190, "y": 32}},
-		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write"},
-		{"from": "ForkWrite", "out": "Out2", "to": "PC", "in": "Write", "points": [{"x": 55, "y": 50}]},
+		{"from": "NotStall", "out": "Write", "to": "OrWrite", "in": "In1", "start": {"x": 175, "y": 12}, "end": {"x": 165, "y": 12}},
+		{"from": "OrWrite", "out": "Out", "to": "ForkWrite", "in": "In", "start": {"x": 150, "y": 32}},
+		{"from": "ForkWrite", "out": "Out1", "to": "IF/ID", "in": "Write", "points": [{"x": 190, "y": 50}]},		{"from": "ForkWrite", "out": "Out2", "to": "PC", "in": "Write", "points": [{"x": 55, "y": 50}]},
 
 		{"from": "ID/EX", "out": "ReadData1", "to": "MuxFwdA", "in": "0", "start": {"x": 405, "y": 248}, "end": {"x": 425, "y": 248}},
 		{"from": "MuxFwdA", "out": "Out", "to": "ALU", "in": "In1", "start": {"x": 440, "y": 250}, "end": {"x": 480, "y": 250}},
@@ -166,9 +168,10 @@
 		{"from": "ForkBr1", "out": "Out2", "to": "EX/MEM", "in": "Flush"},
 		{"from": "ForkBr2", "out": "Out1", "to": "ForkBr3", "in": "In"},
 		{"from": "ForkBr2", "out": "Out2", "to": "OrFlush", "in": "Branch", "end": {"x": 397, "y": 70}},
-		{"from": "ForkBr3", "out": "Out1", "to": "MuxPC", "in": "PCSrc", "points": [{"x": 22, "y": 62}]},
+		{"from": "ForkBr3", "out": "Out1", "to": "ForkBr4", "in": "In"},
 		{"from": "ForkBr3", "out": "Out2", "to": "IF/ID", "in": "Flush"},
-		{"from": "EX/MEM", "out": "MemRead", "to": "DataMem", "in": "MemRead", "start": {"x": 565, "y": 140}, "points": [{"x": 590, "y": 140}], "end": {"x": 590, "y": 242}},
+		{"from": "ForkBr4", "out": "Out1", "to": "MuxPC", "in": "PCSrc", "points": [{"x": 22, "y": 62}]},
+		{"from": "ForkBr4", "out": "Out2", "to": "OrWrite", "in": "In2", "points": [{"x": 170, "y": 22}], "end": {"x": 165, "y": 22}},		{"from": "EX/MEM", "out": "MemRead", "to": "DataMem", "in": "MemRead", "start": {"x": 565, "y": 140}, "points": [{"x": 590, "y": 140}], "end": {"x": 590, "y": 242}},
 		{"from": "EX/MEM", "out": "MemWrite", "to": "DataMem", "in": "MemWrite", "start": {"x": 565, "y": 135}, "points": [{"x": 650, "y": 135}], "end": {"x": 650, "y": 242}},
 		{"from": "EX/MEM", "out": "MemToReg", "to": "MEM/WB", "in": "MemToReg", "start": {"x": 565, "y": 130}, "end": {"x": 680, "y": 130}},
 		{"from": "EX/MEM", "out": "RegWrite", "to": "ForkRegWR1", "in": "In", "start": {"x": 565, "y": 125}},


### PR DESCRIPTION
Sorry it took so long to get this to you.

pipeline.cpu and pipeline-extended.cpu predict branches as not taken. In the MEM stage if it turns out that the branch should have been taken, then the earlier pipeline stages are flushed and the PC is updated to the correct value which is as expected and desired.

However if the Hazard detection unit detects a hazard at this time, it disables writes to the PC, and  therefore the PC never gets updated, meaning that even though we know the branch should have been taken, it is not.

To fix this you must ignore hazards if the MEM stage has determined that the branch was actually taken.

Issue #10 contains some code that demonstrates this issue. If you run the code on the unmodified CPUs you should see the resulting data is not ordered correctly. You can check this against the unicycle.cpu which does sort the list correctly. I'm sure it wouldn't be too hard to create a much simpler program that demonstrates this bug.