### PR TITLE
Added basic support for a having a breakpoint.

### DIFF
--- a/src/pc/src/main/java/brunonova/drmips/pc/FrmSimulator.java
+++ b/src/pc/src/main/java/brunonova/drmips/pc/FrmSimulator.java
@@ -337,6 +337,7 @@ public class FrmSimulator extends javax.swing.JFrame {
         mnuBackStep = new javax.swing.JMenuItem();
         mnuStep = new javax.swing.JMenuItem();
         mnuRun = new javax.swing.JMenuItem();
+        mnuBreak = new javax.swing.JMenuItem();
         jSeparator10 = new javax.swing.JPopupMenu.Separator();
         mnuResetDataBeforeAssembling = new javax.swing.JCheckBoxMenuItem();
         mnuCPU = new javax.swing.JMenu();
@@ -1236,6 +1237,15 @@ public class FrmSimulator extends javax.swing.JFrame {
             }
         });
         mnuExecute.add(mnuRun);
+
+        mnuBreak.setText("add breakpoint");
+        mnuBreak.setEnabled(false);
+        mnuBreak.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                mnuBreakActionPerformed(evt);
+            }
+        });
+        mnuExecute.add(mnuBreak);
         mnuExecute.add(jSeparator10);
 
         mnuResetDataBeforeAssembling.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, java.awt.event.InputEvent.CTRL_MASK));
@@ -1560,6 +1570,10 @@ public class FrmSimulator extends javax.swing.JFrame {
     private void mnuRunActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuRunActionPerformed
 		run();
     }//GEN-LAST:event_mnuRunActionPerformed
+
+    private void mnuBreakActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuBreakActionPerformed
+        addBreakpoint();
+    }//GEN-LAST:event_mnuBreakActionPerformed
 
     private void mnuDocsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuDocsActionPerformed
 		openDocDir();
@@ -2004,6 +2018,7 @@ public class FrmSimulator extends javax.swing.JFrame {
 		Lang.tButton(mnuBackStep, "back_step");
 		Lang.tButton(mnuStep, "step");
 		Lang.tButton(mnuRun, "run");
+		Lang.tButton(mnuBreak, "add breakpoint");
 		Lang.tButton(mnuZoomIn, "zoom_in");
 		Lang.tButton(mnuZoomOut, "zoom_out");
 		Lang.tButton(mnuZoomNormal, "normal");
@@ -2199,6 +2214,7 @@ public class FrmSimulator extends javax.swing.JFrame {
 			mnuRestart.setEnabled(false);
 			mnuStep.setEnabled(false);
 			mnuRun.setEnabled(false);
+			mnuBreak.setEnabled(false);
 			cmdBackStep.setEnabled(false);
 			cmdRestart.setEnabled(false);
 			cmdStep.setEnabled(false);
@@ -2217,6 +2233,7 @@ public class FrmSimulator extends javax.swing.JFrame {
 		boolean enable = !cpu.isProgramFinished();
 		mnuStep.setEnabled(enable);
 		mnuRun.setEnabled(enable);
+		mnuBreak.setEnabled(enable);
 		cmdStep.setEnabled(enable);
 		cmdRun.setEnabled(enable);
 	}
@@ -2337,6 +2354,36 @@ public class FrmSimulator extends javax.swing.JFrame {
 			JOptionPane.showMessageDialog(this, Lang.t("possible_infinite_loop", CPU.EXECUTE_ALL_LIMIT_CYCLES), AppInfo.NAME, JOptionPane.ERROR_MESSAGE);
 		}
 		refreshValues();
+	}
+
+	/**
+	 * Add a breakpoint.
+	 */
+	private void addBreakpoint() {
+
+		String inputValue = JOptionPane.showInputDialog(this, "Set breakpoint address (empty for disable)", AppInfo.NAME, JOptionPane.QUESTION_MESSAGE);
+		if (inputValue == "") {
+			cpu.setBreakpointAddr(-1);
+			return;
+		}
+
+		boolean err = false;
+
+		try {
+			int addr = Integer.parseInt(inputValue);
+			if ((addr < 0) || ((addr % 4) != 0)) {
+				err = true;
+			}
+			else {
+				cpu.setBreakpointAddr(addr);
+			}
+		}
+		catch(NumberFormatException ex) {
+			err = true;
+		}
+
+		if (err)
+			JOptionPane.showMessageDialog(this, "Breakpoint address must positive and a multiple of 4", AppInfo.NAME, JOptionPane.ERROR_MESSAGE);
 	}
 
 	/**
@@ -2914,6 +2961,7 @@ public class FrmSimulator extends javax.swing.JFrame {
     private javax.swing.JMenuItem mnuRestart;
     private javax.swing.JMenuItem mnuRestoreLatencies;
     private javax.swing.JMenuItem mnuRun;
+    private javax.swing.JMenuItem mnuBreak;
     private javax.swing.JMenuItem mnuSave;
     private javax.swing.JMenuItem mnuSaveAs;
     private javax.swing.JMenuItem mnuSelectAll;

--- a/src/simulator/src/main/java/brunonova/drmips/simulator/CPU.java
+++ b/src/simulator/src/main/java/brunonova/drmips/simulator/CPU.java
@@ -119,6 +119,8 @@ public class CPU {
 	private int stalls = 0;
 	/** Whether the latencies and critical path should depend on the current instruction. */
 	private boolean performanceInstructionDependent = false;
+	/** Breakpoint addr . */
+	private int breakpointAddr = -1;
 
 	/**
 	 * Constructor that should by called by other constructors.
@@ -604,6 +606,7 @@ public class CPU {
 
 	/**
 	 * Executes the currently loaded program until the end.
+	 * Or until we hit the breakpoint
 	 * @throws InfiniteLoopException If the <tt>EXECUTE_ALL_LIMIT_CYCLES</tt> limit has been reached (possible infinite loop).
 	 */
 	public void executeAll() throws InfiniteLoopException {
@@ -612,7 +615,20 @@ public class CPU {
 			if(cycles++ > EXECUTE_ALL_LIMIT_CYCLES) // prevent possible infinite cycles
 				throw new InfiniteLoopException();
 			executeCycle();
+
+			// check if we have hit the breakpoint
+			if (getPC().getAddress().getValue() == breakpointAddr)
+			{
+				break;
+			}
 		}
+	}
+
+	/**
+	 * Sets the breakpoint address.
+	 */
+	public void setBreakpointAddr(int addr) {
+		breakpointAddr = addr;
 	}
 
 	/**


### PR DESCRIPTION
This commit allows you to add a breakpoint to stop the CPU running on reaching a certain instruction.

I had to implement this when debugging Issue #10 since it took too long to step through the 1000s of cycles necessary to reach a point where it went wrong. However I wouldn't consider it as a fully implemented feature, it definitely has it's limitations so I would understand if you don't want to accept this pull request / use it as a base for fully implementing this feature.

The interface is a bit clunky, but I don't really do UI design and am not familiar enough with java to make this neat.

If you do decide to accept this pull request I would suggest expanding on it to allow double clicking an instruction in the Code window and similar in the Assembled window, plus some nice GUI indications of which instruction has the breakpoint on. Additionally having multiple breakpoints would be nice.

Oh and also the only way to disable the breakpoint is to use the add breakpoint window and enter nothing when prompted.